### PR TITLE
Feature/cantor docker compose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /lib/
+/public/templates_c

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM php:8.3-apache
+
+WORKDIR /var/www/html
+RUN a2enmod rewrite
+
+COPY . .

--- a/app/controllers/LoginCtrl.class.php
+++ b/app/controllers/LoginCtrl.class.php
@@ -42,7 +42,7 @@ class LoginCtrl {
         
         $database->select("user", "*", [
 	"AND" => [
-		"login" => $this->form->login,,
+		"login" => $this->form->login,
 		"password" => $this->form->password
                 ]
         ]);

--- a/config.php
+++ b/config.php
@@ -4,14 +4,14 @@ $conf->debug = true; # set true during development and use in your code (for ins
 # ---- Webapp location
 $conf->server_name = 'localhost';   # server address and port
 $conf->protocol = 'http';           # http or https
-$conf->app_root = '/cantor/public';   # project subfolder in domain (relative to main domain)
+$conf->app_root = '/public';        # project subfolder in domain (relative to main domain)
 
 # ---- Database config - values required by Medoo
 $conf->db_type = 'mysql';
-$conf->db_server = 'localhost';
-$conf->db_name = '_database_name';
-$conf->db_user = '_user';
-$conf->db_pass = '_password';
+$conf->db_server = getenv('DB_HOST');
+$conf->db_name = getenv('DB_NAME');
+$conf->db_user = getenv('DB_USER');
+$conf->db_pass = getenv('DB_PASSWORD');
 $conf->db_charset = 'utf8';
 
 # ---- Database config - optional values

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -45,3 +45,4 @@ services:
 
 volumes:
   mysql_cantor_data:
+  

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -45,4 +45,3 @@ services:
 
 volumes:
   mysql_cantor_data:
-  

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,47 @@
+version: '3.1'
+
+services:
+  db:
+    image: mysql:latest
+    container_name: my-mysql
+    environment:
+      MYSQL_ROOT_PASSWORD: example
+      MYSQL_DATABASE: cantor_db
+      MYSQL_USER: user
+      MYSQL_PASSWORD: password
+    ports:
+      - "3306:3306"
+    volumes:
+      - mysql_cantor_data:/var/lib/mysql
+
+  phpmyadmin:
+    image: phpmyadmin/phpmyadmin:latest
+    container_name: my-phpmyadmin
+    environment:
+      PMA_HOST: db
+      PMA_USER: root
+      PMA_PASSWORD: example
+      PMA_ARBITRARY: 1
+    ports:
+      - "8080:80"
+    depends_on:
+      - db
+
+  web:
+    build:
+      dockerfile: ./Dockerfile
+    container_name: my-php
+    environment:
+      DB_HOST: db
+      DB_USER: root
+      DB_PASSWORD: example
+      DB_NAME: cantordb
+    volumes:
+      - .:/var/www/html
+    ports:
+      - "80:80"
+    depends_on:
+      - db
+
+volumes:
+  mysql_cantor_data:


### PR DESCRIPTION
Added docker compose and fixed couple of bugs.

# Instruction
[Install docker](https://docs.docker.com/engine/install/).

Then in the root of the project, execute following command:
```bash
docker compose up -d
```

It will spin up latest mysql container and:

- Cantor application running on port 80: `http://localhost`.
- phpmyadmin interface running on port 8080: `http://localhost:8080`.

Now file `cantordbscript.sql` can be imported without any errors using phpmyadmin.
<img width="1377" alt="Screenshot 2024-06-12 at 14 38 49" src="https://github.com/krzychit/KW_PSS/assets/39681631/4ad2aee3-064d-4d38-bb59-4250eb767f12">
